### PR TITLE
Share2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10326,6 +10326,11 @@
         "whatwg-fetch": "^3.0.0"
       }
     },
+    "react-confirm-alert": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-2.6.2.tgz",
+      "integrity": "sha512-lvlk+Sic7p3wbOcsetkCHVXA3LJCDViqjO8sV7FtCfJwjw36ZKCJv2FiaxUCiw3g8PXvmpjEtvAvLqPKb8yh/A=="
+    },
     "react-contextmenu": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/react-contextmenu/-/react-contextmenu-2.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/user-event": "^7.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
+    "react-confirm-alert": "^2.6.2",
     "react-contextmenu": "^2.14.0",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.3"

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -18,6 +18,7 @@ class App extends Component {
   constructor() {
     super();
     this.state = {
+      primaryAccount: {},
       userList: [],
       uploadRequests: [],
       lastRefreshTime: Date().substring(0, 21),
@@ -818,10 +819,14 @@ findTopLevelFolders = (fileList) => {
           login_hint: email,
           discoveryDocs: [discoveryUrl],
         }, (response) => {
-          console.log(response)
           if (response.error) {
             console.log(response.error);
           }
+          const primary = this.state.primaryAccount
+          primary.accessToken = response.access_token;
+          this.setState((prevState) => ({
+            primaryAccount : primary
+          }));
           func.call(this, ...args)
         });
       });
@@ -831,6 +836,7 @@ findTopLevelFolders = (fileList) => {
     return (...args) => {
     const userToken = primaryAccount.idToken;
     const email = this.parseIDToken(userToken).email
+    console.log(this.state.primaryAccount)
     window.gapi.client.load('drive', 'v3').then(() => {
       window.gapi.auth2.authorize({
         apiKey: API_KEY,

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -22,6 +22,7 @@ class App extends Component {
       userList: [],
       uploadRequests: [],
       lastRefreshTime: Date().substring(0, 21),
+      userId : userId
     };
   }
 
@@ -170,7 +171,8 @@ class App extends Component {
           files: [],
           sortedBy: 'folder, viewedByMeTime desc',
           email : email
-        }
+        },
+        userId : userId += 1
       }));
     } else {
       this.setState((prevState) => ({
@@ -186,7 +188,8 @@ class App extends Component {
           openFolders: [],
           sortedBy: 'folder, viewedByMeTime desc',
         }], 
-        primaryAccount : prevState.primaryAccount
+        primaryAccount : prevState.primaryAccount,
+        userId : userId += 1
       }));
     }
     userId +=1;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -58,6 +58,7 @@ class App extends Component {
           console.log('authorization error');
           return;
         }
+        console.log(response)
         const accessToken = response.access_token;
         const idToken = response.id_token;
         const { code } = response;
@@ -785,7 +786,6 @@ findTopLevelFolders = (fileList) => {
   }
 
   load_authorize = (id, func, primaryAccount, isDeletingTempSharedFile) => {
-    console.log('loadauth called')
     if (primaryAccount === undefined) {
     const email = this.getEmailFromUserId(id);
     return (...args) => {
@@ -808,7 +808,6 @@ findTopLevelFolders = (fileList) => {
   } else if (!isDeletingTempSharedFile) {
     const userToken = primaryAccount.idToken;
     const email = this.parseIDToken(userToken).email;
-    console.log(email)
     return (...args) => {
       window.gapi.load('drive-share', () => {
         window.gapi.auth2.authorize({

--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -104,21 +104,17 @@ deletePermission = (permId) => {
 
 
 initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, deletePermi) => {
-  console.log('initshare')
-  console.log(share)
     const fileId = this.props.data.id;
     const { userId } = this.props;
     const primaryUser = this.props.primaryAccount;
     const email = this.props.email;
     let isIncluded = false;
-    console.log(primaryUser)
     for (let i = 0; i< primaryUser.files.length; i++) {
       if (primaryUser.files[i].id === fileId) {
         isIncluded = true;
         break;
       }
     }
-    console.log(isIncluded)
     if (isIncluded) {
       share()
   } else {
@@ -132,7 +128,6 @@ initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, dele
     const { userId } = this.props;
     const primaryUser = this.props.primaryAccount;
       let s = new window.gapi.drive.share.ShareClient()
-      console.log(s)
       s.setOAuthToken(primaryUser.accessToken)
       s.setItemIds(fileId);
       s.showSettingsDialog()
@@ -164,11 +159,10 @@ initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, dele
     const { userId } = this.props;
     const primaryUser = this.props.primaryAccount;
     let s = new window.gapi.drive.share.ShareClient()
-    console.log(s)
     s.setOAuthToken(primaryUser.accessToken)
     s.setItemIds(fileId);
     s.showSettingsDialog()
-    refreshAll = this.props.refreshAllFunc;
+    const refreshAll = this.props.refreshAllFunc;
     //if Yes is selected to share with primary
     if (findPermi === undefined) {
       refreshAll();
@@ -189,7 +183,6 @@ initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, dele
 
     
    submit = (share, shareInternal, shareExternal, findPermi, findFilePermi, deletePermi) => {
-     console.log('submit')
     const primaryUser = this.props.primaryAccount;
     if (primaryUser.email === this.props.email) {
       this.initShare(share, shareInternal, shareExternal)
@@ -233,9 +226,9 @@ initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, dele
     const findPermissionFunc1 = loadAuth(userId, this.findPermission, primaryAccount, true);
     const findFilePermissionFunc1 = loadAuth(userId, this.findFilePermission, primaryAccount, true);
     const deletePermissionFunc1 = loadAuth(userId, this.deletePermission, primaryAccount, true);
-    const shareFunc = loadAuth(1, this.share, primaryAccount)
+    const shareFunc = loadAuth(1, this.share, primaryAccount, false)
     const shareInternalFunc = loadAuth(userId, this.shareInternal)
-    const shareExternalFunc = loadAuth(1, this.shareExternal, primaryAccount)
+    const shareExternalFunc = loadAuth(1, this.shareExternal, primaryAccount, false)
     if (displayed) {
       if (mimeType !== 'application/vnd.google-apps.folder') {
       // if file

--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -191,6 +191,9 @@ initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, dele
    submit = (share, shareInternal, shareExternal, findPermi, findFilePermi, deletePermi) => {
      console.log('submit')
     const primaryUser = this.props.primaryAccount;
+    if (primaryUser.email === this.props.email) {
+      this.initShare(share, shareInternal, shareExternal)
+    } else {
     confirmAlert({
       title: 'Are you trying to share with ' + primaryUser.email + "?",
       message: 'To accomplish sharing, this file must be briefly shared with '  + primaryUser.email + ', and then will be unshared once complete. Select yes if ' + primaryUser.email + ' is an intended recipient of the share.',
@@ -205,6 +208,7 @@ initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, dele
         }
       ]
     });
+  }
   };
 
   

--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -300,7 +300,7 @@ initShare = (share, shareInternal, shareExternal, findPermi, findFilePermi, dele
               View on Google Drive
             </MenuItem>
             <hr className="divider" />
-            <MenuItem className="menu-item" onClick={() => this.submit(share, shareInternal, shareExternal )}>
+            <MenuItem className="menu-item" onClick={() => this.submit(shareFunc, shareInternalFunc, shareExternalFunc, findPermissionFunc1, findFilePermissionFunc1, deletePermissionFunc1 )}>
               <FontAwesomeIcon className="menu-icon" icon={faShare} />
               Share
             </MenuItem>

--- a/src/components/LooseFileList.jsx
+++ b/src/components/LooseFileList.jsx
@@ -6,7 +6,8 @@ import './FileList.css';
 export default function LooseFileList(props) {
   const {
     fileList, fileContainerStyles, userId, copyFunc, deleteFunc, renameFunc, openChildrenFunc,
-    looseFileList, moveExternal, shareFile, moveWithin, isDisplayed, loadAuth, refreshFunc, email
+    looseFileList, moveExternal, shareFile, moveWithin, isDisplayed, loadAuth, refreshFunc, email,
+    primaryAccount
   } = props;
 
   if (isDisplayed) {
@@ -29,6 +30,7 @@ export default function LooseFileList(props) {
             loadAuth={loadAuth}
             refreshFunc = {refreshFunc}
             email = {email}
+            primaryAccount ={primaryAccount}
           />
         ))}
       </div>

--- a/src/components/LooseFileList.jsx
+++ b/src/components/LooseFileList.jsx
@@ -7,7 +7,7 @@ export default function LooseFileList(props) {
   const {
     fileList, fileContainerStyles, userId, copyFunc, deleteFunc, renameFunc, openChildrenFunc,
     looseFileList, moveExternal, shareFile, moveWithin, isDisplayed, loadAuth, refreshFunc, email,
-    primaryAccount
+    primaryAccount, refreshAllFunc
   } = props;
 
   if (isDisplayed) {
@@ -31,6 +31,7 @@ export default function LooseFileList(props) {
             refreshFunc = {refreshFunc}
             email = {email}
             primaryAccount ={primaryAccount}
+            refreshAllFunc = {refreshAllFunc}
           />
         ))}
       </div>

--- a/src/components/OpenFolder.jsx
+++ b/src/components/OpenFolder.jsx
@@ -17,7 +17,7 @@ class OpenFolder extends Component {
   render() {
     const {
       userId, fileList, openChildrenFunc, fileObj, filePath, filepathTraceFunc, closeFolderFunc, moveExternal, moveWithin,
-      shareFile, loadAuth, refreshFunc, email, primaryAccount
+      shareFile, loadAuth, refreshFunc, email, primaryAccount, refreshAllFunc
     } = this.props;
 
     return (
@@ -51,6 +51,7 @@ class OpenFolder extends Component {
               refreshFunc = {refreshFunc}
               email = {email}
               primaryAccount = {primaryAccount}
+              refreshAllFunc = {refreshAllFunc}
             />
           ))}
         </div>

--- a/src/components/OpenFolder.jsx
+++ b/src/components/OpenFolder.jsx
@@ -17,7 +17,7 @@ class OpenFolder extends Component {
   render() {
     const {
       userId, fileList, openChildrenFunc, fileObj, filePath, filepathTraceFunc, closeFolderFunc, moveExternal, moveWithin,
-      shareFile, loadAuth, refreshFunc, email
+      shareFile, loadAuth, refreshFunc, email, primaryAccount
     } = this.props;
 
     return (
@@ -50,6 +50,7 @@ class OpenFolder extends Component {
               fileObj={file}
               refreshFunc = {refreshFunc}
               email = {email}
+              primaryAccount = {primaryAccount}
             />
           ))}
         </div>

--- a/src/components/OpenFolderList.jsx
+++ b/src/components/OpenFolderList.jsx
@@ -6,7 +6,7 @@ import './FileList.css';
 export default function OpenFolderList(props) {
   const {
     fileList, fileContainerStyles, userId, openChildrenFunc, openFolderList, buildChildrenArray, filepathTraceFunc,
-    closeFolderFunc, moveExternal, moveWithin, shareFile, loadAuth, email, primaryAccount
+    closeFolderFunc, moveExternal, moveWithin, shareFile, loadAuth, email, primaryAccount, refreshAllFunc
   } = props;
 
   return (
@@ -30,6 +30,7 @@ export default function OpenFolderList(props) {
           loadAuth={loadAuth}
           email = {email}
           primaryAccount = {primaryAccount}
+          refreshAllFunc = {refreshAllFunc}
         />
       ))}
     </div>

--- a/src/components/OpenFolderList.jsx
+++ b/src/components/OpenFolderList.jsx
@@ -6,7 +6,7 @@ import './FileList.css';
 export default function OpenFolderList(props) {
   const {
     fileList, fileContainerStyles, userId, openChildrenFunc, openFolderList, buildChildrenArray, filepathTraceFunc,
-    closeFolderFunc, moveExternal, moveWithin, shareFile, loadAuth, email,
+    closeFolderFunc, moveExternal, moveWithin, shareFile, loadAuth, email, primaryAccount
   } = props;
 
   return (
@@ -29,6 +29,7 @@ export default function OpenFolderList(props) {
           moveWithin={moveWithin}
           loadAuth={loadAuth}
           email = {email}
+          primaryAccount = {primaryAccount}
         />
       ))}
     </div>

--- a/src/components/TopLevelFolderList.jsx
+++ b/src/components/TopLevelFolderList.jsx
@@ -6,7 +6,8 @@ import './FileList.css';
 export default function TopLevelFolderList(props) {
   const {
     fileList, fileContainerStyles, userId, topLevelFolderList, openChildrenFunc,
-    moveExternal, shareFile, moveWithin, loadAuth, refreshFunc, email, primaryAccount
+    moveExternal, shareFile, moveWithin, loadAuth, refreshFunc, email, primaryAccount,
+    refreshAllFunc
   } = props;
 
   return (
@@ -28,6 +29,7 @@ export default function TopLevelFolderList(props) {
           refreshFunc = {refreshFunc}
           email = {email}
           primaryAccount = {primaryAccount}
+          refreshAllFunc = {refreshAllFunc}
         />
       ))}
     </div>

--- a/src/components/TopLevelFolderList.jsx
+++ b/src/components/TopLevelFolderList.jsx
@@ -6,7 +6,7 @@ import './FileList.css';
 export default function TopLevelFolderList(props) {
   const {
     fileList, fileContainerStyles, userId, topLevelFolderList, openChildrenFunc,
-    moveExternal, shareFile, moveWithin, loadAuth, refreshFunc, email
+    moveExternal, shareFile, moveWithin, loadAuth, refreshFunc, email, primaryAccount
   } = props;
 
   return (
@@ -27,6 +27,7 @@ export default function TopLevelFolderList(props) {
           loadAuth={loadAuth}
           refreshFunc = {refreshFunc}
           email = {email}
+          primaryAccount = {primaryAccount}
         />
       ))}
     </div>

--- a/src/components/User.jsx
+++ b/src/components/User.jsx
@@ -120,6 +120,10 @@ class User extends Component {
     });
     return window.gapi.client.drive.files.create({
       resource: reqBody,
+    }).then((response) => {
+      console.log(response)
+    }, (error) => {
+      alert('Error, could not create file');
     });
   }
 
@@ -129,7 +133,7 @@ class User extends Component {
     const {
       parseIDToken, removeFunc, userId, idToken, fileList, refreshFunc, isChildFunc, topLevelFolderList,
       openChildrenFunc, looseFileList, openFolderList, buildChildrenArray, filepathTraceFunc, closeFolderFunc,
-      fileUpload, sortFunc, currentSort, moveWithin, loadAuth, moveExternal,
+      fileUpload, sortFunc, currentSort, moveWithin, loadAuth, moveExternal, primaryAccount
     } = this.props;
 
     const { name, email, picture } = parseIDToken(idToken);
@@ -278,6 +282,7 @@ class User extends Component {
           moveExternal={moveExternal}
           refreshFunc={refreshFunc}
           email={email}
+          primaryAccount={primaryAccount}
         />
 
         <OpenFolderList
@@ -295,6 +300,7 @@ class User extends Component {
           moveExternal={moveExternal}
           refreshFunc={refreshFunc}
           email={email}
+          primaryAccount={primaryAccount}
         />
         <LooseFileList
           fileList={fileList}
@@ -309,6 +315,7 @@ class User extends Component {
           moveExternal={moveExternal}
           refreshFunc={refreshFunc}
           email={email}
+          primaryAccount={primaryAccount}
         />
       </ContextMenuTrigger>
     );

--- a/src/components/User.jsx
+++ b/src/components/User.jsx
@@ -133,7 +133,7 @@ class User extends Component {
     const {
       parseIDToken, removeFunc, userId, idToken, fileList, refreshFunc, isChildFunc, topLevelFolderList,
       openChildrenFunc, looseFileList, openFolderList, buildChildrenArray, filepathTraceFunc, closeFolderFunc,
-      fileUpload, sortFunc, currentSort, moveWithin, loadAuth, moveExternal, primaryAccount
+      fileUpload, sortFunc, currentSort, moveWithin, loadAuth, moveExternal, primaryAccount, refreshAllFunc
     } = this.props;
 
     const { name, email, picture } = parseIDToken(idToken);
@@ -283,6 +283,7 @@ class User extends Component {
           refreshFunc={refreshFunc}
           email={email}
           primaryAccount={primaryAccount}
+          refreshAllFunc = {refreshAllFunc}
         />
 
         <OpenFolderList
@@ -301,6 +302,7 @@ class User extends Component {
           refreshFunc={refreshFunc}
           email={email}
           primaryAccount={primaryAccount}
+          refreshAllFunc = {refreshAllFunc}
         />
         <LooseFileList
           fileList={fileList}
@@ -316,6 +318,7 @@ class User extends Component {
           refreshFunc={refreshFunc}
           email={email}
           primaryAccount={primaryAccount}
+          refreshAllFunc = {refreshAllFunc}
         />
       </ContextMenuTrigger>
     );

--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -7,7 +7,7 @@ export default function UserList(props) {
   const {
     userList, parseIDToken, removeFunc, refreshFunc, isChildFunc, openChildrenFunc,
     buildChildrenArray, filepathTraceFunc, closeFolderFunc, fileUpload, sortFunc, moveExternal, moveWithin,
-    loadAuth,
+    loadAuth, primaryAccount
   } = props;
   return (
     <div className="user-list">
@@ -34,6 +34,7 @@ export default function UserList(props) {
           moveWithin={moveWithin}
           loadAuth={loadAuth}
           moveExternal={moveExternal}
+          primaryAccount={primaryAccount}
         />
       ))}
     </div>

--- a/src/components/UserList.jsx
+++ b/src/components/UserList.jsx
@@ -7,7 +7,7 @@ export default function UserList(props) {
   const {
     userList, parseIDToken, removeFunc, refreshFunc, isChildFunc, openChildrenFunc,
     buildChildrenArray, filepathTraceFunc, closeFolderFunc, fileUpload, sortFunc, moveExternal, moveWithin,
-    loadAuth, primaryAccount
+    loadAuth, primaryAccount, refreshAllFunc
   } = props;
   return (
     <div className="user-list">
@@ -35,6 +35,7 @@ export default function UserList(props) {
           loadAuth={loadAuth}
           moveExternal={moveExternal}
           primaryAccount={primaryAccount}
+          refreshAllFunc = {refreshAllFunc}
         />
       ))}
     </div>


### PR DESCRIPTION
## Description

Sharing using Google's share menu (instead of Robert's). Now keeps track of your "primary account", which is the 1st account you log into UniDrive with. Note, this should never change. Sharing will break if you refresh the page and change the primary account, but this shouldn't be a problem if there is persistent storage so that the primary account can't change no matter what. Right now primary account is set to the account whose UserId = 1.

Fixes #97 
